### PR TITLE
Fix rails_helper

### DIFF
--- a/templates/files/spec/rails_helper.rb
+++ b/templates/files/spec/rails_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+
+require "rspec/rails"
+
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end

--- a/templates/files/spec/spec_helper.rb
+++ b/templates/files/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+  config.disable_monkey_patching!
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+end

--- a/templates/rspec.rb
+++ b/templates/rspec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+def source_paths
+  [__dir__]
+end
+
 gem_group :development, :test do
   gem "rspec-rails"
 end
@@ -8,54 +12,8 @@ run_bundle
 generate "rspec:install"
 run "bundle binstubs rspec-core"
 
-run "rm spec/spec_helper.rb"
-file "spec/spec_helper.rb", <<-RUBY.strip_heredoc
-  RSpec.configure do |config|
-    config.expect_with :rspec do |expectations|
-      expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    end
-
-    config.mock_with :rspec do |mocks|
-      mocks.verify_partial_doubles = true
-    end
-    config.shared_context_metadata_behavior = :apply_to_host_groups
-    config.filter_run_when_matching :focus
-    config.example_status_persistence_file_path = 'spec/examples.txt'
-    config.disable_monkey_patching!
-    config.default_formatter = 'doc' if config.files_to_run.one?
-    config.profile_examples = 10
-    config.order = :random
-    Kernel.srand config.seed
-  end
-RUBY
-
-run "rm spec/rails_helper.rb"
-file "spec/rails_helper.rb", <<~RUBY.strip_heredoc
-  # frozen_string_literal: true
-
-  require "spec_helper"
-
-  ENV["RAILS_ENV"] ||= "test"
-  require_relative "../config/environment"
-  abort("The Rails environment is running in production mode!") if Rails.env.production?
-
-  require "rspec/rails"
-
-  Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-
-  begin
-    ActiveRecord::Migration.maintain_test_schema!
-  rescue ActiveRecord::PendingMigrationError => e
-    puts e.to_s.strip
-    exit 1
-  end
-  RSpec.configure do |config|
-    config.fixture_path = "#{::Rails.root}/spec/fixtures"
-    config.use_transactional_fixtures = true
-    config.infer_spec_type_from_file_location!
-    config.filter_rails_from_backtrace!
-  end
-RUBY
+copy_file("files/spec/spec_helper.rb", "spec/spec_helper.rb")
+copy_file("files/spec/rails_helper.rb", "spec/rails_helper.rb")
 
 append_to_file ".gitignore" do
   "\nspec/examples.txt\n"


### PR DESCRIPTION
## Summary
Resolves issue #8

Moves `spec/spec_helper.rb` and `spec/rails_helper.rb` to templates/files.

## Test plan
1. generate a new app with `rails new app1 --minimal`
2. apply `templates/rspec.rb` template
3. see `spec/rails_helper.rb` file
4. It should contain `config.fixture_path = "#{::Rails.root}/spec/fixtures"`
5. It shouldn't contain `config.fixture_path = ".../app1/spec/fixtures"`
