### PR TITLE
Add GraphQL base features

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,0 +1,9 @@
+# graphql-rails-template
+Adds GraphQL library to Ruby on Rails application
+- graphql
+- graphiql-rails
+
+Usage:
+```bash
+bin/rails app:template LOCATION=../rails-template/templates/graphql/base.rb
+```

--- a/templates/graphql.rb
+++ b/templates/graphql.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-gem "graphql"
-
-run_bundle
-
-rails_command "generate graphql:install"

--- a/templates/graphql/base.rb
+++ b/templates/graphql/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+def source_paths
+  [__dir__]
+end
+
+unless defined? GraphQL
+  gem "graphql"
+  run_bundle
+end
+
+unless defined? ApplicationSchema
+  rails_command "generate graphql:install --schema=ApplicationSchema"
+  run_bundle
+
+  copy_file(
+    "files/graphql_controller.rb",
+    "app/controllers/graphql_controller.rb"
+  )
+end

--- a/templates/graphql/files/graphql_controller.rb
+++ b/templates/graphql/files/graphql_controller.rb
@@ -1,0 +1,61 @@
+class GraphqlController < ApplicationController
+  def execute
+    render json: execute_query
+  rescue StandardError => e
+    raise e unless Rails.env.development?
+    handle_error_in_development(e)
+  end
+
+  private
+
+  def execute_query
+    ApplicationSchema.execute(
+      params[:query],
+      variables: prepare_variables(params[:variables]),
+      context: execution_context.deep_symbolize_keys,
+      operation_name: params[:operationName]
+    )
+  end
+
+  def execution_context
+    current_user_context.merge(extensions: prepare_variables(params[:extensions]))
+  end
+
+  def current_user_context
+    return {} unless respond_to?(:current_user)
+
+    {
+      current_user: current_user,
+      token: token,
+      token_payload: payload
+    }
+  end
+
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    error = { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }
+
+    render json: error, status: :internal_server_error
+  end
+end


### PR DESCRIPTION
## Summary
Resolves #15.

Adding graphql and graphiql base if it is not defined yet.

## Test plan
1. generate a new app with `rails new appname --minimal`
2. apply `graphql/base` template by
```
bin/rails app:template LOCATION=templates/graphql/base.rb
```
4. run the server, open /graphiql path
5. It should work and show application GraphQL Schema
