### PR TITLE
Add slim template

### DIFF
--- a/templates/slim.rb
+++ b/templates/slim.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-views_path = "app/views/"
-question = "Do you want to start auto-conversion of current templates to slim? IT IS UNSAFE!"
-
 gem "slim-rails"
 run_bundle
 
-if yes?(question)
-  gem 'html2slim'
+if yes?("Do you want to start auto-conversion of current templates to slim? IT IS UNSAFE!")
+  gem "html2slim"
   run_bundle
-  run "erb2slim -d #{views_path}"
-  run 'bundle remove html2slim'
+  run "erb2slim -d app/views/"
+  run "bundle remove html2slim"
   run_bundle
 end

--- a/templates/slim.rb
+++ b/templates/slim.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+question = "Would you like to Slim generators for Rails 3+ too (a.k.a. slim-rails)?"
+slim_gem = yes?(question) ? "slim-rails" : "slim"
+
+gem slim_gem
+run_bundle

--- a/templates/slim.rb
+++ b/templates/slim.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
-question = "Would you like to Slim generators for Rails 3+ too (a.k.a. slim-rails)?"
-slim_gem = yes?(question) ? "slim-rails" : "slim"
-
-gem slim_gem
+gem "slim-rails"
 run_bundle

--- a/templates/slim.rb
+++ b/templates/slim.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
+views_path = "app/views/"
+question = "Do you want to start auto-conversion of current templates to slim? IT IS UNSAFE!"
+
 gem "slim-rails"
 run_bundle
+
+if yes?(question)
+  gem 'html2slim'
+  run_bundle
+  run "erb2slim -d #{views_path}"
+  run 'bundle remove html2slim'
+  run_bundle
+end


### PR DESCRIPTION
## Summary
Resolves #19.

Add slim template. In beginning it asks if you need Slim generators for Rails 3+ and installs:
`yes`: gem 'slim-rails'
`no`: gem 'slim'

## Test plan
0. Apply `templates/slim.rb` template
