### PR TITLE
Change rubocop auto-correct command

### DIFF
--- a/templates/rubocop.rb
+++ b/templates/rubocop.rb
@@ -49,5 +49,5 @@ end
 
 run "bundle binstubs rubocop"
 
-count_of_files = Dir["**/*"].length
-run "bin/rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit #{count_of_files}"
+files_count = Dir["app/**/*", "lib/**/*", "spec/**/*", "test/**/*", "config/**/*"].length
+run "bin/rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit #{files_count}"

--- a/templates/rubocop.rb
+++ b/templates/rubocop.rb
@@ -48,4 +48,6 @@ append_to_file ".gitattributes" do
 end
 
 run "bundle binstubs rubocop"
-run "bin/rubocop -A"
+
+count_of_files = Dir["**/*"].length
+run "bin/rubocop --auto-gen-config --auto-gen-only-exclude --exclude-limit #{count_of_files}"


### PR DESCRIPTION
## Summary
Resolves #18.

Now the rubocop template generates a todo file instead of automatically resolving all offenses.

## Test plan
1. Generate a new app / Select an existing one.
2. Apply `rubocop` template.
3. You should see `.rubocop-todo.yml` with all the offenses in your project.
