### PR TITLE
Add Semaphore template

### DIFF
--- a/templates/semaphore/README.md
+++ b/templates/semaphore/README.md
@@ -1,0 +1,10 @@
+# semaphore-template
+Adds Semaphore CI to Ruby on Rails application
+
+Usage:
+```bash
+bin/rails app:template LOCATION=../rails-template/templates/semaphore/base.rb
+```
+
+### See also:
+- [Rails Continuous Integration (Official Documentation)](https://docs.semaphoreci.com/examples/rails-continuous-integration/)

--- a/templates/semaphore/base.rb
+++ b/templates/semaphore/base.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+def gem_installed?(gem_name)
+  Gem::Specification.find_by_name(gem_name)
+rescue Gem::LoadError
+  nil
+end
+
+file ".semaphore/semaphore.yml", <<~YAML
+  version: v1.0
+  name: Ruby on Rails CI
+  agent:
+    machine:
+      type: e1-standard-2
+      os_image: ubuntu2004
+  auto_cancel:
+    running:
+      when: true
+  fail_fast:
+    stop:
+      when: true
+
+  global_job_config:
+    prologue:
+      commands:
+        - checkout
+        - cache restore
+        #{'- sem-service start postgres' if defined? PG}
+        - sem-version ruby #{RUBY_VERSION}
+        - bundle install
+        - cache store
+
+  blocks:
+    - name: Test
+      task:
+        jobs:
+          - name: Run tests
+            commands:
+              - bundle exec rails db:setup
+              #{'- bundle exec rspec' if gem_installed? 'rspec-rails'}
+
+    - name: Lint
+      task:
+        jobs:
+          - name: Run quality
+            commands:
+              #{'- bundle exec bundler-audit --update' if gem_installed? 'bundler-audit'}
+              #{'- bundle exec brakeman' if gem_installed? 'brakeman'}
+              #{'- bundle exec rubocop  --parallel' if gem_installed? 'rubocop'}
+YAML


### PR DESCRIPTION
## Summary
Resolves #28.

Added Semaphore template which adds `semaphore.yml` file (Adaptation of [Github Actions template](https://github.com/DmitryBarskov/rails-template/blob/main/templates/github_actions.rb)).

## Test plan
1. Apply `semaphore/base` template by
`bin/rails app:template LOCATION=templates/semaphore/base.rb`
2. In Semaphore, follow the link in the sidebar to create a new project. Follow the instructions to install sem CLI and connect it to your organization
3. Run `sem init` inside your repository
4. Commit & push changes
5. Make sure that your pushed commit is green.

## References
- [Rails Continuous Integration (Official Documentation)](https://docs.semaphoreci.com/examples/rails-continuous-integration/)